### PR TITLE
Remove EnableWebMvc annotation to restore Thymeleaf view

### DIFF
--- a/src/main/java/ch/clip/trips/SpringWebConfig.java
+++ b/src/main/java/ch/clip/trips/SpringWebConfig.java
@@ -2,11 +2,9 @@ package ch.clip.trips;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-@EnableWebMvc
 public class SpringWebConfig implements WebMvcConfigurer {
 	/**
 	 * CORS - Policy - from known Servers


### PR DESCRIPTION
## Summary
- remove `@EnableWebMvc` from `SpringWebConfig` so Spring Boot can auto-configure Thymeleaf

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685ff3b5690c832ea5049e24c7ad36dc