### PR TITLE
Fix TripNotFoundException naming

### DIFF
--- a/src/main/java/ch/clip/trips/ex/TripNotFoundAdvice.java
+++ b/src/main/java/ch/clip/trips/ex/TripNotFoundAdvice.java
@@ -10,9 +10,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 public class TripNotFoundAdvice {
 
 	@ResponseBody
-	@ExceptionHandler(TriptNotFoundException.class)
-	@ResponseStatus(HttpStatus.NOT_FOUND)
-	String productNotFoundHandler(TriptNotFoundException ex) {
+        @ExceptionHandler(TripNotFoundException.class)
+        @ResponseStatus(HttpStatus.NOT_FOUND)
+        String tripNotFoundHandler(TripNotFoundException ex) {
 		return ex.getMessage();
 	}
 }

--- a/src/main/java/ch/clip/trips/ex/TripNotFoundException.java
+++ b/src/main/java/ch/clip/trips/ex/TripNotFoundException.java
@@ -1,9 +1,9 @@
 package ch.clip.trips.ex;
 
-public class TriptNotFoundException extends RuntimeException {
+public class TripNotFoundException extends RuntimeException {
 	private static final long serialVersionUID = 7334815941308526816L;
 
-	public TriptNotFoundException(Long id ) {
+        public TripNotFoundException(Long id ) {
 		super("could not find trip "+id);
 	}
 


### PR DESCRIPTION
## Summary
- rename `TriptNotFoundException` to `TripNotFoundException`
- update `TripNotFoundAdvice` to use new name and a clearer handler method

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffaf59310832e997f9606603aba6f