### PR TITLE
Add employee and flight management

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Projektübersicht
 
-Das Business Trips Backend ist eine Spring Boot REST API Anwendung zur Verwaltung von Geschäftsreisen und zugehörigen Meetings. Die Anwendung verwendet eine 2-Tier Architektur mit JPA für die Datenpersistierung.
+Das Business Trips Backend ist eine Spring Boot REST API Anwendung zur Verwaltung von Geschäftsreisen und zugehörigen Meetings. Die Anwendung verwendet eine 2-Tier Architektur mit JPA für die Datenpersistierung. Das Datenmodell umfasst nun auch Mitarbeiter sowie dazugehörige Flüge.
 
 ### Technologie-Stack
 - **Backend**: Java 21, Spring Boot 3.2.6

--- a/src/main/java/ch/clip/trips/BusinessTripsBackendApplication.java
+++ b/src/main/java/ch/clip/trips/BusinessTripsBackendApplication.java
@@ -13,8 +13,12 @@ import org.springframework.context.annotation.Bean;
 
 import ch.clip.trips.model.BusinessTrip;
 import ch.clip.trips.model.Meeting;
+import ch.clip.trips.model.Employee;
+import ch.clip.trips.model.Flight;
 import ch.clip.trips.repo.BusinessTripRepository;
 import ch.clip.trips.repo.MeetingRepository;
+import ch.clip.trips.repo.EmployeeRepository;
+import ch.clip.trips.repo.FlightRepository;
 
 @SpringBootApplication
 public class BusinessTripsBackendApplication {
@@ -25,12 +29,34 @@ public class BusinessTripsBackendApplication {
 	}
 
 	@Bean
-	public CommandLineRunner demoData(BusinessTripRepository businessTripRepository,
-			MeetingRepository meetingRepository) {
+       public CommandLineRunner demoData(BusinessTripRepository businessTripRepository,
+                       MeetingRepository meetingRepository,
+                       EmployeeRepository employeeRepository,
+                       FlightRepository flightRepository) {
 		// https://spring.io/guides/gs/accessing-data-jpa/
-		return (args) -> {
+                return (args) -> {
 
-			// save a couple of BusinessTrips
+                        // create employees
+                        Employee alice = new Employee();
+                        alice.setId(1L);
+                        alice.setName("Alice");
+                        alice.setTitle("Engineer");
+
+                        Employee bob = new Employee();
+                        bob.setId(2L);
+                        bob.setName("Bob");
+                        bob.setTitle("Consultant");
+
+                        Employee carol = new Employee();
+                        carol.setId(3L);
+                        carol.setName("Carol");
+                        carol.setTitle("Manager");
+
+                        employeeRepository.save(alice);
+                        employeeRepository.save(bob);
+                        employeeRepository.save(carol);
+
+                        // save a couple of BusinessTrips
 			BusinessTrip bt01 = new BusinessTrip(1L, "BT01",
 					"San Francisco World Trade Center on new Server/IOT/Client ", LocalDateTime.of(2021, 2, 13, 9, 00),
 					LocalDateTime.of(2021, 2, 15, 16, 56));
@@ -57,8 +83,12 @@ public class BusinessTripsBackendApplication {
 					LocalDateTime.of(2023, 2, 10, 9, 0), LocalDateTime.of(2023, 2, 12, 17, 0));
 			BusinessTrip bt12 = new BusinessTrip(12L, "BT12", "Barcelona IoT showcase",
 					LocalDateTime.of(2023, 5, 3, 8, 30), LocalDateTime.of(2023, 5, 7, 20, 0));
-			BusinessTrip bt13 = new BusinessTrip(13L, "BT13", "Dubai logistics client visits",
-					LocalDateTime.of(2023, 9, 9, 10, 15), LocalDateTime.of(2023, 9, 14, 17, 30));
+                        BusinessTrip bt13 = new BusinessTrip(13L, "BT13", "Dubai logistics client visits",
+                                        LocalDateTime.of(2023, 9, 9, 10, 15), LocalDateTime.of(2023, 9, 14, 17, 30));
+
+                        bt01.setEmployees(List.of(alice, bob));
+                        bt02.setEmployees(List.of(bob));
+                        bt03.setEmployees(List.of(carol));
 			businessTripRepository.save(bt01);
 			businessTripRepository.save(bt02);
 			businessTripRepository.save(bt03);
@@ -83,9 +113,27 @@ public class BusinessTripsBackendApplication {
 
 			meetingRepository.save(one);
 			meetingRepository.save(zero);
-			meetingRepository.save(handsOn);
-			meetingRepository.save(workOn);
-			meetingRepository.save(stayTuned);
+                        meetingRepository.save(handsOn);
+                        meetingRepository.save(workOn);
+                        meetingRepository.save(stayTuned);
+
+                        // flights for employees
+                        Flight fl1 = new Flight();
+                        fl1.setId(1L);
+                        fl1.setNumber("LX123");
+                        fl1.setFrom("ZRH");
+                        fl1.setTo("SFO");
+                        fl1.setEmployee(alice);
+
+                        Flight fl2 = new Flight();
+                        fl2.setId(2L);
+                        fl2.setNumber("BA456");
+                        fl2.setFrom("LHR");
+                        fl2.setTo("ZRH");
+                        fl2.setEmployee(bob);
+
+                        flightRepository.save(fl1);
+                        flightRepository.save(fl2);
 
 			// List<Trips>
 

--- a/src/main/java/ch/clip/trips/controller/EmployeeController.java
+++ b/src/main/java/ch/clip/trips/controller/EmployeeController.java
@@ -1,0 +1,82 @@
+package ch.clip.trips.controller;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import ch.clip.trips.model.Employee;
+import ch.clip.trips.repo.EmployeeRepository;
+
+@RestController
+@RequestMapping("/v1")
+@CrossOrigin(origins = "*")
+public class EmployeeController {
+
+    @Autowired
+    private EmployeeRepository employeeRepository;
+
+    @GetMapping("/employees")
+    public ResponseEntity<List<Employee>> getAllEmployees() {
+        List<Employee> employees = employeeRepository.findAll();
+        if (employees.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(employees);
+    }
+
+    @GetMapping("/employees/{id}")
+    public ResponseEntity<Employee> getEmployeeById(@PathVariable Long id) {
+        Optional<Employee> employee = employeeRepository.findById(id);
+        return employee.map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/employees")
+    public ResponseEntity<Employee> createEmployee(@RequestBody Employee newEmployee) {
+        try {
+            Employee saved = employeeRepository.save(newEmployee);
+            return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @PutMapping("/employees/{id}")
+    public ResponseEntity<Employee> updateEmployee(@RequestBody Employee newEmployee, @PathVariable Long id) {
+        try {
+            Employee updated = employeeRepository.findById(id)
+                .map(emp -> {
+                    emp.setName(newEmployee.getName());
+                    emp.setTitle(newEmployee.getTitle());
+                    return employeeRepository.save(emp);
+                })
+                .orElseGet(() -> {
+                    newEmployee.setId(id);
+                    return employeeRepository.save(newEmployee);
+                });
+            return ResponseEntity.ok(updated);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @DeleteMapping("/employees/{id}")
+    public ResponseEntity<Void> deleteEmployee(@PathVariable Long id) {
+        if (!employeeRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        employeeRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/ch/clip/trips/controller/FlightController.java
+++ b/src/main/java/ch/clip/trips/controller/FlightController.java
@@ -1,0 +1,86 @@
+package ch.clip.trips.controller;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import ch.clip.trips.model.Flight;
+import ch.clip.trips.repo.FlightRepository;
+
+@RestController
+@RequestMapping("/v1")
+@CrossOrigin(origins = "*")
+public class FlightController {
+
+    @Autowired
+    private FlightRepository flightRepository;
+
+    @GetMapping("/flights")
+    public ResponseEntity<List<Flight>> getAllFlights() {
+        List<Flight> flights = flightRepository.findAll();
+        if (flights.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(flights);
+    }
+
+    @GetMapping("/flights/{id}")
+    public ResponseEntity<Flight> getFlightById(@PathVariable Long id) {
+        Optional<Flight> flight = flightRepository.findById(id);
+        return flight.map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/flights")
+    public ResponseEntity<Flight> createFlight(@RequestBody Flight newFlight) {
+        try {
+            Flight saved = flightRepository.save(newFlight);
+            return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @PutMapping("/flights/{id}")
+    public ResponseEntity<Flight> updateFlight(@RequestBody Flight newFlight, @PathVariable Long id) {
+        try {
+            Flight updated = flightRepository.findById(id)
+                .map(flight -> {
+                    flight.setNumber(newFlight.getNumber());
+                    flight.setFrom(newFlight.getFrom());
+                    flight.setTo(newFlight.getTo());
+                    if (newFlight.getEmployee() != null) {
+                        flight.setEmployee(newFlight.getEmployee());
+                    }
+                    return flightRepository.save(flight);
+                })
+                .orElseGet(() -> {
+                    newFlight.setId(id);
+                    return flightRepository.save(newFlight);
+                });
+            return ResponseEntity.ok(updated);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @DeleteMapping("/flights/{id}")
+    public ResponseEntity<Void> deleteFlight(@PathVariable Long id) {
+        if (!flightRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        flightRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/ch/clip/trips/model/BusinessTrip.java
+++ b/src/main/java/ch/clip/trips/model/BusinessTrip.java
@@ -4,11 +4,16 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.OneToMany;
+
+import ch.clip.trips.model.Employee;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 
@@ -27,9 +32,18 @@ public class BusinessTrip implements Serializable {
 	private LocalDateTime startTrip;
 	private LocalDateTime endTrip;
 
-	@OneToMany(mappedBy = "businessTrip")
-	@JsonManagedReference
-	private List<Meeting> meetings;
+        @OneToMany(mappedBy = "businessTrip")
+        @JsonManagedReference
+        private List<Meeting> meetings;
+
+        @ManyToMany
+        @JoinTable(
+          name = "Businesstrip_has_Employee",
+          joinColumns = @JoinColumn(name = "Businesstrip_idBusinesstrip"),
+          inverseJoinColumns = @JoinColumn(name = "Employee_idEmployee")
+        )
+        @JsonManagedReference
+        private List<Employee> employees;
 
 
 	public BusinessTrip() {
@@ -72,13 +86,21 @@ public class BusinessTrip implements Serializable {
 		this.description = description;
 	}
 
-	public List<Meeting> getMeetings() {
-		return meetings;
-	}
+        public List<Meeting> getMeetings() {
+                return meetings;
+        }
 
-	public void setMeetings(List<Meeting> meetings) {
-		this.meetings = meetings;
-	}
+        public void setMeetings(List<Meeting> meetings) {
+                this.meetings = meetings;
+        }
+
+        public List<Employee> getEmployees() {
+                return employees;
+        }
+
+        public void setEmployees(List<Employee> employees) {
+                this.employees = employees;
+        }
 
 
 
@@ -100,9 +122,9 @@ public class BusinessTrip implements Serializable {
 
 	@Override
 	public String toString() {
-		return "BusinessTrip [id=" + id + ", title=" + title + ", description=" + description + ", startTrip="
-				+ startTrip + ", endTrip=" + endTrip + ", meetings=" + meetings + "]";
-	}
+                return "BusinessTrip [id=" + id + ", title=" + title + ", description=" + description + ", startTrip="
+                                + startTrip + ", endTrip=" + endTrip + ", meetings=" + meetings + ", employees=" + employees + "]";
+        }
 
 
 

--- a/src/main/java/ch/clip/trips/model/Employee.java
+++ b/src/main/java/ch/clip/trips/model/Employee.java
@@ -1,0 +1,34 @@
+package ch.clip.trips.model;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
+
+import lombok.Data;
+
+@Data
+@Entity
+public class Employee implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String title;
+
+    @ManyToMany(mappedBy = "employees")
+    @JsonBackReference
+    private List<BusinessTrip> businessTrips;
+
+    @OneToMany(mappedBy = "employee")
+    @JsonManagedReference
+    private List<Flight> flights;
+}

--- a/src/main/java/ch/clip/trips/model/Flight.java
+++ b/src/main/java/ch/clip/trips/model/Flight.java
@@ -1,0 +1,36 @@
+package ch.clip.trips.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+import lombok.Data;
+
+@Data
+@Entity
+public class Flight implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String number;
+
+    @Column(name = "origin")
+    private String from;
+
+    @Column(name = "destination")
+    private String to;
+
+    @ManyToOne
+    @JoinColumn(name = "employee_id")
+    @JsonBackReference
+    private Employee employee;
+}

--- a/src/main/java/ch/clip/trips/repo/EmployeeRepository.java
+++ b/src/main/java/ch/clip/trips/repo/EmployeeRepository.java
@@ -1,0 +1,8 @@
+package ch.clip.trips.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import ch.clip.trips.model.Employee;
+
+public interface EmployeeRepository extends JpaRepository<Employee, Long> {
+}

--- a/src/main/java/ch/clip/trips/repo/FlightRepository.java
+++ b/src/main/java/ch/clip/trips/repo/FlightRepository.java
@@ -1,0 +1,8 @@
+package ch.clip.trips.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import ch.clip.trips.model.Flight;
+
+public interface FlightRepository extends JpaRepository<Flight, Long> {
+}


### PR DESCRIPTION
## Summary
- introduce `Employee` and `Flight` entities
- link employees to business trips via many-to-many
- create repositories and REST controllers for new entities
- preload demo data with employees, flights and relations
- update documentation mentioning employees and flights

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629a0cc2b0832e9ee54ea60dfc68d4