### PR TITLE
Handle delete conflicts globally

### DIFF
--- a/src/main/java/ch/clip/trips/controller/BusinessTripController.java
+++ b/src/main/java/ch/clip/trips/controller/BusinessTripController.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -100,14 +101,17 @@ public class BusinessTripController {
      * @return ResponseEntity with no content
      */
     @DeleteMapping("/trips/{id}")
-    public ResponseEntity<Void> deleteTrip(@PathVariable Long id) {
+    public ResponseEntity<String> deleteTrip(@PathVariable Long id) {
         if (!tripRepository.existsById(id)) {
             return ResponseEntity.notFound().build(); // 404 Not Found
         }
-        
+
         try {
             tripRepository.deleteById(id);
             return ResponseEntity.noContent().build(); // 204 No Content
+        } catch (DataIntegrityViolationException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("Cannot delete business trip. It is referenced by other entities.");
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build(); // 500 Internal Server Error
         }

--- a/src/main/java/ch/clip/trips/controller/EmployeeController.java
+++ b/src/main/java/ch/clip/trips/controller/EmployeeController.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -72,11 +73,16 @@ public class EmployeeController {
     }
 
     @DeleteMapping("/employees/{id}")
-    public ResponseEntity<Void> deleteEmployee(@PathVariable Long id) {
+    public ResponseEntity<String> deleteEmployee(@PathVariable Long id) {
         if (!employeeRepository.existsById(id)) {
             return ResponseEntity.notFound().build();
         }
-        employeeRepository.deleteById(id);
-        return ResponseEntity.noContent().build();
+        try {
+            employeeRepository.deleteById(id);
+            return ResponseEntity.noContent().build();
+        } catch (DataIntegrityViolationException ex) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("Cannot delete employee. They are still assigned to one or more flights or business trips.");
+        }
     }
 }

--- a/src/main/java/ch/clip/trips/controller/FlightController.java
+++ b/src/main/java/ch/clip/trips/controller/FlightController.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -76,11 +77,16 @@ public class FlightController {
     }
 
     @DeleteMapping("/flights/{id}")
-    public ResponseEntity<Void> deleteFlight(@PathVariable Long id) {
+    public ResponseEntity<String> deleteFlight(@PathVariable Long id) {
         if (!flightRepository.existsById(id)) {
             return ResponseEntity.notFound().build();
         }
-        flightRepository.deleteById(id);
-        return ResponseEntity.noContent().build();
+        try {
+            flightRepository.deleteById(id);
+            return ResponseEntity.noContent().build();
+        } catch (DataIntegrityViolationException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("Cannot delete flight. It is referenced by other entities.");
+        }
     }
 }

--- a/src/main/java/ch/clip/trips/controller/GlobalExceptionHandler.java
+++ b/src/main/java/ch/clip/trips/controller/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.dao.DataIntegrityViolationException;
 
 
 @ControllerAdvice
@@ -14,5 +15,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleUnsupportedMediaType(HttpMediaTypeNotSupportedException ex) {
         return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
                 .body("Unsupported Media Type: " + ex.getMessage());
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<String> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body("Operation not allowed: " + ex.getMostSpecificCause().getMessage());
     }
 }


### PR DESCRIPTION
## Summary
- catch `DataIntegrityViolationException` when deleting employees, flights, trips, and meetings
- provide Conflict HTTP responses with user friendly messages
- add global handler for integrity violations

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686bb2b67abc832ea272810e69f12d34